### PR TITLE
Update rust aws sdk version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "aws-secretsmanager-cache"
 description = "A client for in-process caching of secrets from AWS Secrets manager"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Adam Quigley"]
 edition = "2021"
 license = "MIT OR Apache-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,8 +14,8 @@ categories = ["caching"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-aws-config = "0.0.25-alpha"
-aws-sdk-secretsmanager = "0.0.25-alpha"
+aws-config = "0.2.0"
+aws-sdk-secretsmanager = "0.2.0"
 tokio = { version = "1", features = ["full"] }
 lru = "0.7.0"
 

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -146,14 +146,9 @@ mod tests {
 
     // provides a mocked AWS SecretsManager client for testing
     fn get_mock_secretsmanager_client() -> SecretsManagerClient {
-        let creds = Credentials::from_keys(
-            "ANOTREAL",
-            "notrealrnrELgWzOk3IfjzDKtFBhDby",
-            Some("notarealsessiontoken".to_string()),
-        );
         let conf = Config::builder()
             .region(Region::new("ap-southeast-2"))
-            .credentials_provider(creds)
+            .credentials_provider(Credentials::new("asdf", "asdf", None, None, "test"))
             .build();
 
         SecretsManagerClient::from_conf(conf)


### PR DESCRIPTION
This PR updates the AWS Rust SDK dep to `v0.2.0` based on the latest SDK release https://github.com/awslabs/aws-sdk-rust/releases/tag/v0.2.0. It also bumps the version of this crate to be `v0.2.0`