### PR TITLE
Update aws-sdk-rust to v0.6.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "aws-secretsmanager-cache"
 description = "A client for in-process caching of secrets from AWS Secrets manager"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["Adam Quigley"]
 edition = "2021"
 license = "MIT OR Apache-2.0"
@@ -11,11 +11,9 @@ readme = "README.md"
 keywords = ["aws", "aws-secrets-manager", "aws-sdk-rust", "LRU", "cache"]
 categories = ["caching"]
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]
-aws-config = "0.2.0"
-aws-sdk-secretsmanager = "0.2.0"
+aws-config = "0.6.0"
+aws-sdk-secretsmanager = "0.6.0"
 tokio = { version = "1", features = ["full"] }
 lru = "0.7.0"
 


### PR DESCRIPTION
Updates the `aws-sdk-rust` dependency to `v.0.6.0` https://github.com/awslabs/aws-sdk-rust/releases/tag/v0.6.0