### PR TITLE
Reduce string allocations

### DIFF
--- a/examples/get-secret-global.rs
+++ b/examples/get-secret-global.rs
@@ -22,7 +22,7 @@ async fn main() {
         .await
         .lock() // acquire cache lock
         .unwrap()
-        .get_secret_string(secret_id.to_string())
+        .get_secret_string(secret_id)
         .send()
         .await
     {

--- a/examples/get-secret-with-config.rs
+++ b/examples/get-secret-with-config.rs
@@ -15,7 +15,7 @@ async fn main() {
     let secret_id = "service/secret";
 
     match cache
-        .get_secret_string(secret_id.to_string())
+        .get_secret_string(secret_id)
         .force_refresh() // force the value to be fetched from AWS and updated in the cache
         .send()
         .await

--- a/examples/get-secret.rs
+++ b/examples/get-secret.rs
@@ -9,7 +9,7 @@ async fn main() {
 
     let secret_id = "service/secret";
 
-    match cache.get_secret_string(secret_id.to_string()).send().await {
+    match cache.get_secret_string(secret_id).send().await {
         Ok(secret_value) => {
             println!(
                 "Successfully retrieved secret {}: {}",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,7 +22,7 @@
 //!
 //!     let secret_id = "service/secret";
 //!
-//!     match cache.get_secret_string(secret_id.to_string()).send().await {
+//!     match cache.get_secret_string(secret_id).send().await {
 //!         Ok(secret_value) => {
 //!             // do something
 //!         }


### PR DESCRIPTION
This is a bit of a breaking change since the API moves from String to &str. The reasons are
1. to make the API more friendly (no need to use to_string on the input parameter) and
2. to greatly reduce the number of String allocations required in the code (we only allocate an ID as a String when it is about to be put in the cache)